### PR TITLE
Re-enable SSL certificate validation

### DIFF
--- a/pypodio2/transport.py
+++ b/pypodio2/transport.py
@@ -38,7 +38,7 @@ class OAuthAuthorization(object):
                 'client_secret': secret,
                 'username': login,
                 'password': password}
-        h = Http(disable_ssl_certificate_validation=True)
+        h = Http()
         headers = {'content-type': 'application/x-www-form-urlencoded'}
         response, data = h.request(domain + "/oauth/token", "POST",
                                    urlencode(body), headers=headers)
@@ -56,7 +56,7 @@ class OAuthRefreshTokenAuthorization(object):
                 'client_id': client_id,
                 'client_secret': client_secret,
                 'refresh_token': refresh_token}
-        http = Http(disable_ssl_certificate_validation=True)
+        http = Http()
         headers = {'content-type': 'application/x-www-form-urlencoded'}
         response, data = http.request(domain + '/oauth/token', 'POST',
                                       urlencode(body), headers=headers)
@@ -74,7 +74,7 @@ class OAuthAppAuthorization(object):
                 'client_secret': secret,
                 'app_id': app_id,
                 'app_token': app_token}
-        h = Http(disable_ssl_certificate_validation=True)
+        h = Http()
         headers = {'content-type': 'application/x-www-form-urlencoded'}
         response, data = h.request(domain + "/oauth/token", "POST",
                                    urlencode(body), headers=headers)
@@ -125,7 +125,7 @@ class HttpTransport(object):
         self._attribute_stack = []
         self._method = "GET"
         self._posts = []
-        self._http = Http(disable_ssl_certificate_validation=True)
+        self._http = Http()
         self._params = {}
         self._url_template = '%(domain)s/%(generated_url)s'
         self._stack_collapser = "/".join


### PR DESCRIPTION
SLL certificate validation was disabled in this two commits https://github.com/wbrp/podio-py/commit/b72c058b449c200628b517f0aab5ab9c1adb6f1b https://github.com/wbrp/podio-py/commit/a06b4766a4583da92f99b10a4ba366589723de22 

We don't know the reason, but re-enabling it doesn't seem to cause any problems. Those commits are back from 2012, so the issue then might have disappeared.